### PR TITLE
Remove excess useState call, save timeout handler using closure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,20 +2,19 @@ import { useState, useEffect, useRef } from 'react';
 
 export const useThrottle = (value, limit) => {
   const [throttledValue, setThrottledValue] = useState(value);
-  const [lastRan, setLastRan] = useState(Date.now());
-  const handler = useRef();
+  const lastRan = useRef(Date.now());
 
   useEffect(
     () => {
-      handler.current = setTimeout(function() {
-        if (Date.now() - lastRan >= limit) {
+      const handler = setTimeout(function() {
+        if (Date.now() - lastRan.current >= limit) {
           setThrottledValue(value);
-          setLastRan(Date.now());
+          lastRan.current = Date.now();
         }
-      }, limit - (Date.now() - lastRan));
+      }, limit - (Date.now() - lastRan.current));
 
       return () => {
-        clearTimeout(handler.current);
+        clearTimeout(handler);
       };
     },
     [value, limit]


### PR DESCRIPTION
Hello, @bhaskarGyan! Thank you for your lib!

I made some minor improvements in this library:
1) removed useState for lastRan — this field doesn't have any influence on the render result of the component. So I used useRef to store lastRan value between the component rerenders. useRef is handy to keep any mutable value, during component renders. Here is some more information about it: https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables 

2) removed useRef for the `handler`. `handler` is being used only in useEffect, so we can use closures to work with it and its cleanup